### PR TITLE
Qt4 libqscintilla2.so is installed in libdir/qt4/

### DIFF
--- a/sci-geosciences/qgis/qgis-2.18.10.ebuild
+++ b/sci-geosciences/qgis/qgis-2.18.10.ebuild
@@ -123,7 +123,7 @@ src_configure() {
 
 	if has_version '<x11-libs/qscintilla-2.10'; then
 		mycmakeargs+=(
-			-DQSCINTILLA_LIBRARY=/usr/$(get_libdir)/libqscintilla2.so
+			-DQSCINTILLA_LIBRARY=/usr/$(get_libdir)/qt4/libqscintilla2.so
 		)
 	fi
 


### PR DESCRIPTION
Without this correction the emerge halts when cmake cannot find libqscintilla2.so. With this patch qgis emerges correctly on my qt4 system.