### PR TITLE
Update qgis-9999.ebuild

### DIFF
--- a/sci-geosciences/qgis/qgis-9999.ebuild
+++ b/sci-geosciences/qgis/qgis-9999.ebuild
@@ -44,7 +44,7 @@ COMMON_DEPEND="
 	dev-qt/qtsql:5
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
-	sci-libs/gdal:=[geos,python?,${PYTHON_USEDEP}]
+	>=sci-libs/gdal-2.1.3:=[geos,python?,${PYTHON_USEDEP}]
 	sci-libs/geos
 	sci-libs/libspatialindex:=
 	sci-libs/proj
@@ -93,9 +93,6 @@ RDEPEND="${COMMON_DEPEND}
 RESTRICT="test"
 
 PATCHES=(
-	# TODO upstream
-	"${FILESDIR}/${PN}-2.18.6-featuresummary.patch"
-	"${FILESDIR}/${PN}-2.18.6-python.patch"
 	# Taken from redhat
 	"${FILESDIR}/${PN}-2.18.12-sip.patch"
 	# git master
@@ -181,10 +178,10 @@ src_install() {
 
 	local size type
 	for size in 16 22 24 32 48 64 96 128 256; do
-		newicon -s ${size} debian/${PN}-icon${size}x${size}.png ${PN}.png
-		newicon -c mimetypes -s ${size} debian/${PN}-mime-icon${size}x${size}.png ${PN}-mime.png
+		newicon -s ${size} debian/icons/${PN}-icon${size}x${size}.png ${PN}.png
+		newicon -c mimetypes -s ${size} debian/icons/${PN}-mime-icon${size}x${size}.png ${PN}-mime.png
 		for type in qgs qml qlr qpt; do
-			newicon -c mimetypes -s ${size} debian/${PN}-${type}${size}x${size}.png ${PN}-${type}.png
+			newicon -c mimetypes -s ${size} debian/icons/${PN}-${type}${size}x${size}.png ${PN}-${type}.png
 		done
 	done
 	newicon -s scalable images/icons/qgis_icon.svg qgis.svg


### PR DESCRIPTION
I got the ebuild to emerge after making the following changes:

1. Enforce `>=sci-libs/gdal-2.1.3`; it is not in portage yet, but can be found via https://bugs.gentoo.org/615986
2. icons now in `debian/icons` instead of `debian`
3. removed two TODO upstream patches that did not apply